### PR TITLE
Fix issue 39 by simplifying gene pool initialization code

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -129,22 +129,15 @@ end
 function initialize_state()
     println("initialize_state()")
 
-    # Initialize gene pool as an (n_loci, n_genes_initial) matrix filled with
-    # allele IDs drawn uniformly randomly in 1:n_alleles_per_locus_initial.
-    # and to avoid duplications, 10 times of random numbers are draw and then reduced to a set.
-    gene_pool = reshape(
-        rand(1:P.n_alleles_per_locus_initial, P.n_loci * P.n_genes_initial*10),
-        (P.n_loci, P.n_genes_initial*10)
-    )
+    # Initialize gene pool as an (n_loci, n_genes_initial) matrix whose columns
+    # are unique randomly generated genes.
     gene_pool_set = Set()
-    i = 1
-    while length(gene_pool_set)<P.n_genes_initial
-        push!(gene_pool_set, gene_pool[:,i])
-        i+=1
+    while length(gene_pool_set) < P.n_genes_initial
+        push!(gene_pool_set, rand(1:P.n_alleles_per_locus_initial, P.n_loci))
     end
-    gene_pool = Array{Int}(undef, P.n_loci, 0)
-    for gene in gene_pool_set
-        gene_pool = hcat(gene_pool, gene)
+    gene_pool = zeros(AlleleId, P.n_loci, P.n_genes_initial)
+    for (i, gene) in enumerate(gene_pool_set)
+        gene_pool[:,i] = gene
     end
 
     # Initialize n_hosts hosts, all born at t = 0, with lifetime drawn from a

--- a/src/state.jl
+++ b/src/state.jl
@@ -309,6 +309,13 @@ Verify that various pieces of state are consistent with each other.
 function verify(t, s::State)
     println("verify($(t), s)")
 
+    # Verify that gene pool consists of all unique genes
+    gene_pool_set = Set()
+    for i in 1:size(s.gene_pool)[2]
+        push!(gene_pool_set, s.gene_pool[:,i])
+    end
+    @assert length(gene_pool_set) == size(s.gene_pool)[2]
+
     for host in s.hosts
         if P.n_infections_liver_max !== missing
             @assert length(host.liver_infections) <= P.n_infections_liver_max


### PR DESCRIPTION
Now just creates individual random genes directly into `gene_pool_set`, and then copies them into the `gene_pool` array. Also added code to `verify()` to verify uniquness of genes.