### PR TITLE
[WIP] Gamma-distributed liver stage

### DIFF
--- a/examples/json/generate-json.jl
+++ b/examples/json/generate-json.jl
@@ -100,6 +100,7 @@ function init_params()
         mutation_rate = 1.42e-8,
 
         t_liver_stage = 14.0,
+        gamma_shape_liver_stage = 14,
 
         switching_rate = 1.0/6.0,
 

--- a/examples/julia/run.jl
+++ b/examples/julia/run.jl
@@ -79,6 +79,7 @@ const P = let
         mutation_rate = 1.42e-8,
 
         t_liver_stage = 14.0,
+        gamma_shape_liver_stage = 14,
 
         switching_rate = 1.0/6.0,
 

--- a/examples/sweep/generate-sweep.jl
+++ b/examples/sweep/generate-sweep.jl
@@ -296,6 +296,7 @@ function init_base_params()
         mutation_rate = 1.42e-8,
 
         t_liver_stage = 14.0,
+        gamma_shape_liver_stage = 14,
 
         switching_rate = 1.0/6.0,
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -231,11 +231,19 @@ keyword constructor for the class.
     mutation_rate::Union{Float64, Nothing} = nothing
 
     """
-    Duration of the liver stage.
+    Mean duration of the liver stage.
 
     Infections become active after `t_liver_stage` units of time.
     """
     t_liver_stage::Union{Float64, Nothing} = nothing
+
+    """
+    Shape parameter of the gamma (Erlang) distribution for liver stage duration.
+
+    The shape must be an integer, since the delay is implemented via a series
+    of exponential draws (`gamma_shape_liver_stage` of them).
+    """
+    gamma_shape_liver_stage::Union{Int, Nothing} = nothing
 
     """
     Switching rate for genes the host is not immune to.
@@ -408,7 +416,7 @@ function validate(p::Params)
     @assert p.n_genes_initial > 0
 
     @assert p.n_genes_per_strain !== nothing
-    @assert p.n_genes_per_strain > 0
+    @assert 0 < p.n_genes_per_strain <= 127
 
     @assert p.n_loci !== nothing
     @assert p.n_loci > 0
@@ -450,6 +458,9 @@ function validate(p::Params)
 
     @assert p.t_liver_stage !== nothing
     @assert p.t_liver_stage >= 0.0
+
+    @assert p.gamma_shape_liver_stage !== nothing
+    @assert 0 < p.gamma_shape_liver_stage <= 127
 
     @assert p.switching_rate !== nothing
     @assert p.switching_rate >= 0.0

--- a/src/state.jl
+++ b/src/state.jl
@@ -21,7 +21,7 @@ else
 end
 
 const StrainId = UInt32
-const ExpressionIndex = UInt8
+const ExpressionIndex = Int8
 const ExpressionIndexLocus = UInt8
 const ImmunityLevel = UInt16 # UInt8
 const Gene = SVector{P.n_loci, AlleleId}  # Immutable fixed-size vector
@@ -101,9 +101,13 @@ matrix of allele IDs), and the currently expressed index.
     genes::MMatrix{P.n_loci, P.n_genes_per_strain, AlleleId}
 
     """
-    Index in `genes` matrix of currently expressed gene.
+    Advancement index within stage: gamma-distribution step in liver stage;
+    index in `genes` matrix of currently expressed gene in blood stage.
 
-    Set to `0` (and ignored) for liver-stage infections.
+    Liver-stage gamma distribution steps start at
+    `-(gamma_shape_liver_stage - 1)` and end at `0`.
+
+    Blood-stage steps start at 1.
     """
     expression_index::ExpressionIndex
 
@@ -326,7 +330,7 @@ function verify(t, s::State)
         end
 
         for infection in host.liver_infections
-            @assert infection.expression_index == 0
+            @assert -(P.gamma_shape_liver_stage - 1) <= infection.expression_index <= 0
         end
 
         for infection in host.active_infections


### PR DESCRIPTION
I began modifications to eliminate the fixed-time liver stage. This should be considered, at the moment, a work in progress, although the code does run and seems to be doing the right thing.

Changes:

* `gamma_shape_liver_stage` determines the shape of the gamma distribution for liver-stage delays (whose mean is `t_liver_stage`)
* `expression_index` is used to track progress through the chain of exponential draws that result in the gamma- (Erlang-)distributed liver stage.
* `advance_host!()` only checks for host death, not liver-stage activation
* Rate calculations no longer allow for the possibility of a liver-stage infection being activated in `advance_host!()`

Outstanding questions:

* Double-check the math: is the mean set correctly?
* Does `advance_immune_genes!()` need to be called everywhere it's called? Is there a more elegant way to handle it in light of the modified code?