### PR TITLE
Speed up exponential sampling with batch draws

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -122,10 +122,13 @@ function run_inner()
     rates = [get_rate(t, s, event) for event in EVENTS]
     total_rate = sum(rates)
 
+    # Batched exponential distribution for event loop draws
+    batched_exp_dist = BatchedDistribution(Exponential(1.0), P.rng_batch_size)
+
     # Loop events until end of simulation.
     while total_rate > 0.0 && t < P.t_end
         # Draw next time with rate equal to the sum of all event rates.
-        dt = rand(Exponential(1.0 / total_rate))
+        dt = rand(batched_exp_dist) / total_rate
         @assert dt > 0.0 && !isinf(dt)
 
         # At each integer time, write output/state verification (if necessary),

--- a/src/output.jl
+++ b/src/output.jl
@@ -254,6 +254,7 @@ function write_output!(db, t, s, stats)
         end        
 
         execute(db, "COMMIT")
+        flush(stdout)
     end
 end
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -418,6 +418,14 @@ keyword constructor for the class.
         Delay between samples
     """
     profile_delay::Float64 = 0.1
+
+    """
+        Batch size for batched exponential draws.
+        Exponential draws are a significant percent of simulation time;
+        drawing them in large batches enables the use of vector (SIMD) instructions
+        for a ~ 4x RNG speedup in isolated tests.
+    """
+    rng_batch_size::Int = 10000000
 end
 
 """

--- a/src/util.jl
+++ b/src/util.jl
@@ -169,3 +169,27 @@ function get_key_by_iteration_order(d::Dict{K, V}, index::Int) where {K, V}
     end
     @assert false
 end
+
+"""
+State for a batched distribution.
+"""
+mutable struct BatchedDistribution
+    d::Sampleable{Univariate, Continuous}
+    draws::Vector{Float64}
+    next_draw_index::Int
+
+    function BatchedDistribution(d, batch_size)
+        draws = Vector(undef, batch_size)
+        next_draw_index = 1
+        new(d, draws, 1)
+    end
+end
+
+function Base.rand(bd::BatchedDistribution)
+    if bd.next_draw_index == 1
+        rand!(bd.d, bd.draws)
+    end
+    draw = bd.draws[bd.next_draw_index]
+    bd.next_draw_index = 1 + mod(bd.next_draw_index, length(bd.draws))
+    draw
+end

--- a/testing/kscompare.ipynb
+++ b/testing/kscompare.ipynb
@@ -1,0 +1,350 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using SQLite\n",
+    "import SQLite.Stmt\n",
+    "import SQLite.DBInterface.execute\n",
+    "using Distributions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "generate_time_series (generic function with 1 method)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Functions to create fake normal data in lieu of actual simulation runs.\n",
+    "\n",
+    "function generate_runs(db, combo_id, n_runs)\n",
+    "    execute(db, \"CREATE TABLE IF NOT EXISTS runs (run_id INTEGER PRIMARY KEY AUTOINCREMENT, combo_id)\")\n",
+    "    stmt = Stmt(db, \"INSERT INTO runs (combo_id) VALUES (?)\")\n",
+    "    for i in 1:n_runs\n",
+    "        execute(stmt, [combo_id])\n",
+    "    end\n",
+    "\n",
+    "end\n",
+    "\n",
+    "function get_run_ids(db, combo_id)\n",
+    "    [run_id for (run_id,) in execute(db, \"SELECT run_id FROM runs WHERE combo_id = ?\", [combo_id])]\n",
+    "end\n",
+    "\n",
+    "function generate_scalar(db, combo_id, tblname, mean, std)\n",
+    "    execute(db, \"CREATE TABLE IF NOT EXISTS $(tblname) (run_id, value)\")\n",
+    "    stmt = Stmt(db, \"INSERT INTO $(tblname) VALUES (?,?)\")\n",
+    "\n",
+    "    run_ids = get_run_ids(db, combo_id)\n",
+    "    x = rand(Normal(mean, std), length(run_ids))\n",
+    "    for (i, run_id,) in enumerate(run_ids)\n",
+    "        execute(stmt, [run_id, x[i]])\n",
+    "    end\n",
+    "end\n",
+    "\n",
+    "function generate_time_series(db, combo_id, tblname, ts, mean, std)\n",
+    "    execute(db, \"CREATE TABLE IF NOT EXISTS $(tblname) (run_id, time, value)\")\n",
+    "    stmt = Stmt(db, \"INSERT INTO $(tblname) VALUES (?,?,?)\")\n",
+    "\n",
+    "    run_ids = get_run_ids(db, combo_id)\n",
+    "    x = rand(Normal(mean, std), (length(ts), length(run_ids)))\n",
+    "    for (j, run_id,) in enumerate(run_ids)\n",
+    "        for (i, t,) in enumerate(ts)\n",
+    "            execute(stmt, (run_id, t, x[i, j]))\n",
+    "        end\n",
+    "    end\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate fake data for two different parameter combinations, 20 runs,\n",
+    "# one scalar value, one time series.\n",
+    "# Scenario: an attempt at improving performance.\n",
+    "# Performance improves, and there is no change in behavior for parameter combination 1.\n",
+    "# However, a bug is introduced that shows up for parameter combination 2.\n",
+    "\n",
+    "db1 = SQLite.DB(\":memory:\")\n",
+    "db2 = SQLite.DB(\":memory:\")\n",
+    "\n",
+    "ts = 0:30:720\n",
+    "\n",
+    "# Parameter combination 1\n",
+    "generate_runs(db1, 1, 20)\n",
+    "generate_runs(db2, 1, 20)\n",
+    "generate_scalar(db1, 1, \"elapsed_time\", 100.0, 10.0) # elapsed_time for code version 1\n",
+    "generate_scalar(db2, 1, \"elapsed_time\",  80.0, 10.0)  # elapsed_time for code version 2 (faster)\n",
+    "generate_time_series(db1, 1, \"moi_mean\", ts, 3, 0.1)   # moi_mean for code version 1\n",
+    "generate_time_series(db2, 1, \"moi_mean\", ts, 3, 0.1)   # moi_mean for code version 2 (same)\n",
+    "\n",
+    "# Parameter combination 2\n",
+    "generate_runs(db1, 2, 20)\n",
+    "generate_runs(db2, 2, 20)\n",
+    "generate_scalar(db1, 2, \"elapsed_time\", 120.0, 15.0) # elapsed_time for code version 1\n",
+    "generate_scalar(db2, 2, \"elapsed_time\", 95.0, 15.0)  # elapsed_time for code version 2 (faster)\n",
+    "generate_time_series(db1, 2, \"moi_mean\", ts, 2, 0.1)   # moi_mean for code version 1\n",
+    "generate_time_series(db2, 2, \"moi_mean\", ts, 1.8, 0.1)   # moi_mean for code version 2 (DIFFERENT - A BUG)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "40-element Vector{Tuple{Float64, Float64}}:\n",
+       " (1.0, 96.10739132606024)\n",
+       " (2.0, 96.43390891319504)\n",
+       " (3.0, 90.68779626106664)\n",
+       " (4.0, 97.0837713852988)\n",
+       " (5.0, 88.00097196150526)\n",
+       " (6.0, 100.28064880702108)\n",
+       " (7.0, 105.41128918764174)\n",
+       " (8.0, 107.21876432068245)\n",
+       " (9.0, 106.54120590419353)\n",
+       " (10.0, 94.70406190474748)\n",
+       " ⋮\n",
+       " (32.0, 103.27127021209616)\n",
+       " (33.0, 147.47591302233732)\n",
+       " (34.0, 102.81179306493615)\n",
+       " (35.0, 133.4888767628679)\n",
+       " (36.0, 127.76579121334862)\n",
+       " (37.0, 107.29684556508111)\n",
+       " (38.0, 130.10599445732956)\n",
+       " (39.0, 112.33961617510523)\n",
+       " (40.0, 125.17763155633828)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "[(run_id, time, value) for (run_id, time, value) in execute(db1, \"SELECT * FROM elapsed_time\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1000-element Vector{Tuple{Int64, Int64, Float64}}:\n",
+       " (1, 0, 3.085437204780984)\n",
+       " (1, 30, 3.01491826337338)\n",
+       " (1, 60, 3.002151546959092)\n",
+       " (1, 90, 2.9686276157402416)\n",
+       " (1, 120, 2.8957891280249024)\n",
+       " (1, 150, 2.925763690134143)\n",
+       " (1, 180, 2.990693215371097)\n",
+       " (1, 210, 2.827404412939092)\n",
+       " (1, 240, 2.8597301025725472)\n",
+       " (1, 270, 3.0422095866029077)\n",
+       " ⋮\n",
+       " (40, 480, 2.126196030443726)\n",
+       " (40, 510, 1.9458964826059553)\n",
+       " (40, 540, 2.0179596544199563)\n",
+       " (40, 570, 1.9275809627277747)\n",
+       " (40, 600, 1.9477441916540292)\n",
+       " (40, 630, 2.080536207619095)\n",
+       " (40, 660, 1.8679463698567846)\n",
+       " (40, 690, 1.7712294594445743)\n",
+       " (40, 720, 1.7590007106519683)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "[(run_id, time, value) for (run_id, time, value) in execute(db1, \"SELECT * FROM moi_mean\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "query_value_for_run_id (generic function with 1 method)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import StatsAPI.pvalue\n",
+    "import StatsBase.mean\n",
+    "import StatsBase.mad\n",
+    "import HypothesisTests.ApproximateTwoSampleKSTest\n",
+    "\n",
+    "# Functions to compare using K-S tests\n",
+    "\n",
+    "\"\"\"\n",
+    "    Do K-S tests using SQLite queries that take one parameter, run_id.\n",
+    "\n",
+    "    `db1` and `db2` are assumed to have identical parameter combinations labeled the same way,\n",
+    "    via the `combo_id` column in the `runs` table.\n",
+    "\n",
+    "    The query should return a single value for the provided run_id.\n",
+    "\n",
+    "    If values from db2 need to be extracted with a different query, provide a value for `q2`.\n",
+    "\"\"\"\n",
+    "function compare(db1, db2, q1; q2 = q1)\n",
+    "    combo_ids = get_combo_ids(db1)\n",
+    "    @assert all(combo_ids .== get_combo_ids(db2))\n",
+    "    [(combo_id, compare(db1, db2, combo_id, q1; q2 = q2)) for combo_id in combo_ids]\n",
+    "end\n",
+    "\n",
+    "function get_combo_ids(db)\n",
+    "    [combo_id for (combo_id,) in execute(db, \"SELECT DISTINCT combo_id FROM runs ORDER BY combo_id\")]\n",
+    "end\n",
+    "\n",
+    "function compare(db1, db2, combo_id, q1; q2 = q1)\n",
+    "    v1 = query_values_for_combo_id(db1, combo_id, q1)\n",
+    "    mean1 = mean(v1)\n",
+    "    mad1 = mad(v1; center = mean1)\n",
+    "\n",
+    "    v2 = query_values_for_combo_id(db2, combo_id, q2)\n",
+    "    mean2 = mean(v2)\n",
+    "    mad2 = mad(v2; center = mean2)\n",
+    "\n",
+    "    (ApproximateTwoSampleKSTest(v1, v2), (mean1, mad1), (mean2, mad2))\n",
+    "end\n",
+    "\n",
+    "function query_values_for_combo_id(db, combo_id, q)\n",
+    "    stmt = Stmt(db, q)\n",
+    "    run_ids = get_run_ids(db, combo_id)\n",
+    "\n",
+    "    [query_value_for_run_id(stmt, run_id) for run_id in run_ids]\n",
+    "end\n",
+    "\n",
+    "function query_value_for_run_id(stmt, run_id)\n",
+    "    for (value,) in execute(stmt, (run_id,))\n",
+    "        return value\n",
+    "    end\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Testing elapsed time for parameter combination 1...\n",
+      "    (mean1 98.52747830909739, mad1 12.75526719689743)\n",
+      "    (mean2 82.05364853311593, mad2 12.779490311421853)\n",
+      "    p-value: 0.0014931716161319915\n",
+      "    DIFFERENT distributions w/ p < 0.01\n",
+      "Testing elapsed time for parameter combination 2...\n",
+      "    (mean1 116.75995982764493, mad1 11.602721168536982)\n",
+      "    (mean2 93.7473968405003, mad2 23.298801787044546)\n",
+      "    p-value: 0.004715723951164094\n",
+      "    DIFFERENT distributions w/ p < 0.01\n"
+     ]
+    }
+   ],
+   "source": [
+    "for (combo_id, (test, (mean1, mad1), (mean2, mad2))) in compare(db1, db2, \"SELECT value FROM elapsed_time WHERE run_id = ?\")\n",
+    "    println(\"Testing elapsed time for parameter combination $(combo_id)...\")\n",
+    "    println(\"    (mean1 $(mean1), mad1 $(mad1))\")\n",
+    "    println(\"    (mean2 $(mean2), mad2 $(mad2))\")\n",
+    "    println(\"    p-value: $(pvalue(test))\")\n",
+    "    if pvalue(test) < 0.01\n",
+    "        println(\"    DIFFERENT distributions w/ p < 0.01\")\n",
+    "    else\n",
+    "        println(\"    undetectable difference between distributions w/ p < 0.01\")\n",
+    "    end\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Testing mean moi over time for parameter combination 1...\n",
+      "    (mean1 3.013226253800627, mad1 0.03880718915594512)\n",
+      "    (mean2 2.996645512220396, mad2 0.020749624789856785)\n",
+      "    p-value: 0.17247627033056145\n",
+      "    undetectable difference between distributions w/ p < 0.01\n",
+      "Testing mean moi over time for parameter combination 2...\n",
+      "    (mean1 2.0020889929805468, mad1 0.02438158593309094)\n",
+      "    (mean2 1.815571544166526, mad2 0.03579324777309966)\n",
+      "    p-value: 4.122307244877057e-9\n",
+      "    DIFFERENT distributions w/ p < 0.01\n"
+     ]
+    }
+   ],
+   "source": [
+    "for (combo_id, (test, (mean1, mad1), (mean2, mad2))) in compare(\n",
+    "        db1, db2,\n",
+    "        \"SELECT AVG(value) FROM moi_mean WHERE run_id = ? AND time >= 360 AND time <= 720\"\n",
+    "    )\n",
+    "    println(\"Testing mean moi over time for parameter combination $(combo_id)...\")\n",
+    "    println(\"    (mean1 $(mean1), mad1 $(mad1))\")\n",
+    "    println(\"    (mean2 $(mean2), mad2 $(mad2))\")\n",
+    "    println(\"    p-value: $(pvalue(test))\")\n",
+    "    if pvalue(test) < 0.01\n",
+    "        println(\"    DIFFERENT distributions w/ p < 0.01\")\n",
+    "    else\n",
+    "        println(\"    undetectable difference between distributions w/ p < 0.01\")\n",
+    "    end\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.10.0",
+   "language": "julia",
+   "name": "julia-1.10"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/testing/kscompare.jl
+++ b/testing/kscompare.jl
@@ -1,0 +1,402 @@
+"""
+    This file contains functions to use Kolmogorov-Smirnov tests to compare output distributions.
+
+    The main reason to do this is to verify that output distributions are the same
+    (er, not-not-the-same) between different versions of code.
+
+    All the functions assume that output from many runs has already been gathered into
+    two SQLite databases (one for each version of the code being compared).
+
+    None of the code here is specific to varmodel3; it can be used to compare outputs between
+    any SQLite databases.
+
+    Comparisons can be made using identical queries for the two databases or different queries
+    for each database, for situations where the output format is different.
+"""
+
+println("(Annoying Julia compilation delay...)")
+
+using SQLite
+import SQLite.DBInterface.execute
+import HypothesisTests.ApproximateTwoSampleKSTest
+import StatsAPI.pvalue
+import StatsBase.mean
+import StatsBase.mad
+using Plots
+using DelimitedFiles
+import Formatting.format
+
+# Get relevant paths and cd to the script path.
+SCRIPT_DIR = abspath(dirname(PROGRAM_FILE))
+cd(SCRIPT_DIR)
+
+function main()
+    db2_path = joinpath(SCRIPT_DIR, "output", "vm2", "sweep_db_gathered.sqlite")
+    if !ispath(db2_path)
+        error("`output/vm2/sweep_db_gathered.sqlite` does not exist; please run gather-output.jl first")
+    end
+    
+    db3_path = joinpath(SCRIPT_DIR, "output", "vm3", "sweep_db_gathered.sqlite")
+    if !ispath(db2_path)
+        error("`output/vm3/sweep_db_gathered.sqlite` does not exist; please run gather-output.jl first")
+    end
+    
+    db2 = SQLite.DB(db2_path)
+    db3 = SQLite.DB(db3_path)
+    
+    ts = [360 * year for year in 0:100]
+
+    for t in ts
+        println("Comparing at t = $(t)...")
+        results = [
+#             compare_moi([t], db2, db3, false),
+#             compare_prevalence([t], db2, db3, false),
+#             compare_nswitch_total([t], db2, db3, false),
+#             compare_nswitch_immune([t], db2, db3, false),
+#             compare_nswitch_not_immune([t], db2, db3, false),
+#             compare_tswitch_sum([t], db2, db3, false),
+#             compare_tswitch_overall([t], db2, db3, false),
+#             compare_tswitch_not_immune([t], db2, db3, false),
+#             compare_n_bites_total([t], db2, db3, false),
+#             compare_n_circulating_genes([t], db2, db3, false),
+#             compare_n_circulating_strains([t], db2, db3, false),
+            compare_n_infected_bites([t], db2, db3, false),
+#             compare_n_bites([t], db2, db3, false),
+            compare_mean_age([t], db2, db3, false),
+            compare_sd_age([t], db2, db3, false),
+        ]
+        for (title, meanmeans2, madmeans2, meanmeans3, madmeans3, pvalue) in results
+            println("-----------")
+            if pvalue > 0.01
+                println("$(title) matches: same distribution in varmodel2 and varmodel3")
+            else
+                println("$(title) DOES NOT match")
+            end
+            println("    p-value = $(format("{:.3e}", pvalue))")
+        end
+        println()
+    end
+
+    ts_end = [360 * year for year in 91:100]
+    results = [
+        compare_moi(ts_end, db2, db3, true),
+        compare_prevalence(ts_end, db2, db3, true),
+        compare_nswitch_total(ts_end, db2, db3, true),
+        compare_nswitch_immune(ts_end, db2, db3, true),
+        compare_nswitch_not_immune(ts_end, db2, db3, true),
+        compare_tswitch_sum(ts_end, db2, db3, true),
+        compare_tswitch_overall(ts_end, db2, db3, true),
+        compare_tswitch_not_immune(ts_end, db2, db3, true),
+        compare_n_bites_total(ts_end, db2, db3, true),
+        compare_n_circulating_genes(ts_end, db2, db3, true),
+        compare_n_circulating_strains(ts_end, db2, db3, true),
+        compare_n_infected_bites(ts_end, db2, db3, false),
+#         compare_n_bites(ts_end, db2, db3, false),
+        compare_mean_age(ts_end, db2, db3, false),
+        compare_sd_age(ts_end, db2, db3, false),
+    ]
+    
+    # Summary
+    println("SUMMARY")
+    for (title, meameans2, madmeans2, meanmeans3, madmeans3, pvalue) in results
+        println("-----------")
+        if pvalue > 0.01
+            println("$(title) matches: same distribution in varmodel2 and varmodel3")
+        else
+            println("$(title) does not match")
+        end
+        println("    p-value = $(format("{:.3e}", pvalue))")
+    end
+    
+    # Save p-values to CSV
+    csv_data = vcat([("measurement", "meanmeans2", "madmeans2", "meanmeans3", "madmeans3", "pvalue")], results)
+    writedlm("output/compare-results.csv", csv_data)
+end
+
+function compare_funcs(name, ts, db2, db3, should_plot, f2, f3)
+    compare_mats(
+        name, ts,
+        get_matrix(ts, db2, f2),
+        get_matrix(ts, db3, f3),
+        should_plot
+    )
+end
+
+function compare_mats(name, ts, mat2, mat3, should_plot)
+    n_reps_2 = size(mat2)[2]
+    n_reps_3 = size(mat3)[2]
+    
+    means2 = mean.(eachcol(mat2))
+    meanmeans2 = mean(means2)
+    madmeans2 = mad(means2; center = meanmeans2)
+    means3 = mean.(eachcol(mat3))
+    meanmeans3 = mean(means3)
+    madmeans3= mad(means3; center = meanmeans3)
+    
+    if should_plot
+        p = plot(ts, hcat(mat2, mat3), lcolor = reshape(vcat(
+                repeat([(:black)], n_reps_2), repeat([(:green)], n_reps_3)
+            ), 1, n_reps_2 + n_reps_3), lalpha = 0.3, label = false, plot_title = name
+        )
+        hline!(p, [meanmeans2], line = (:solid, :black), lw = 2, label = "varmodel2 ($(format("{:.2e} ({:.2e})", meanmeans2, madmeans2)))")
+        hline!(p, [meanmeans3], line = (:solid, :green), lw = 2, label = "varmodel3 ($(format("{:.2e} ({:.2e})", meanmeans3, madmeans3)))")
+        savefig(p, "output/$(name).pdf")
+    end
+    
+    # Test average prevalence during years 90-100
+    test = ApproximateTwoSampleKSTest(means2, means3)
+#     if should_plot
+#         println("Kolmogorov-Smirnov Test of $(name)...")
+#         println("--------")
+#         println("test results:")
+#         print(test)
+#         println("--------")
+#         println()
+#     end
+    
+    (name, meanmeans2, madmeans2, meanmeans3, madmeans3, pvalue(test))
+end
+
+function get_matrix(ts, db, f)
+    run_ids = [run_id for (run_id,) in execute(db, "SELECT DISTINCT run_id FROM debug_stats ORDER BY run_id")]
+    [f(t, db, run_id) for t in ts, run_id in run_ids]
+end
+    
+function compare_moi(ts, db2, db3, should_plot)
+    compare_funcs("moi", ts, db2, db3, should_plot,
+        (
+            function(t, db, run_id)
+                for (n_infections, n_infected) in execute(db,
+                    "SELECT n_infections, n_infected FROM summary WHERE time = ? AND run_id = ?", [t, run_id]
+                )
+                    return n_infections / n_infected
+                end
+            end
+        ),
+        (
+            function(t, db, run_id)
+                    for (n_infections, n_infected) in execute(db3,
+                        "SELECT n_infections_active, n_infected_active FROM summary WHERE time = ? AND run_id = ?", [t, run_id]
+                    )
+                        return n_infections / n_infected
+                    end
+            end
+        )
+    )
+end
+
+function compare_prevalence(ts, db2, db3, should_plot)
+    compare_funcs("prevalence", ts, db2, db3, should_plot,
+        (
+            function(t, db, run_id)
+                for (n_infected,) in execute(db,
+                    "SELECT n_infected FROM summary WHERE time = ? AND run_id = ?", [t, run_id]
+                )
+                    return n_infected / N_HOSTS
+                end
+            end
+        ),
+        (
+            function(t, db, run_id)
+                for (n_infected,) in execute(db3,
+                    "SELECT n_infected_active FROM summary WHERE time = ? AND run_id = ?", [t, run_id]
+                )
+                    return n_infected / N_HOSTS
+                end
+            end
+        )
+    )
+end
+
+function compare_nswitch_total(ts, db2, db3, should_plot)
+    f = function(t, db, run_id)
+        for (n_switch_immune, n_switch_not_immune) in execute(db, 
+            "SELECT n_switch_immune, n_switch_not_immune FROM debug_stats WHERE time = ? AND run_id = ?", [t, run_id]
+        )
+            return Float64(n_switch_immune + n_switch_not_immune)
+        end
+    end
+    compare_funcs("nswitch_total", ts, db2, db3, should_plot, f, f)
+end
+
+function compare_nswitch_immune(ts, db2, db3, should_plot)
+    f = function(t, db, run_id)
+        for (n_switch_immune,) in execute(db, 
+            "SELECT n_switch_immune FROM debug_stats WHERE time = ? AND run_id = ?", [t, run_id]
+        )
+            return Float64(n_switch_immune)
+        end
+    end
+    compare_funcs("nswitch_immune", ts, db2, db3, should_plot, f, f)
+end
+
+function compare_nswitch_not_immune(ts, db2, db3, should_plot)
+    f = function(t, db, run_id)
+        for (n_switch_not_immune,) in execute(db, 
+            "SELECT n_switch_not_immune FROM debug_stats WHERE time = ? AND run_id = ?", [t, run_id]
+        )
+            return Float64(n_switch_not_immune)
+        end
+    end
+    compare_funcs("n_switch_not_immune", ts, db2, db3, should_plot, f, f)
+end
+
+function compare_tswitch_sum(ts, db2, db3, should_plot)
+    f = function(t, db, run_id)
+        for (t_switch_sum,) in execute(db, 
+            "SELECT t_switch_sum FROM debug_stats WHERE time = ? AND run_id = ?", [t, run_id]
+        )
+            return t_switch_sum
+        end
+    end
+    compare_funcs("tswitch_sum", ts, db2, db3, should_plot, f, f)
+end
+
+function compare_tswitch_overall(ts, db2, db3, should_plot)
+    f = function(t, db, run_id)
+        for (n_switch_immune, n_switch_not_immune, t_switch_sum) in execute(db, 
+            "SELECT n_switch_immune, n_switch_not_immune, t_switch_sum FROM debug_stats WHERE time = ? AND run_id = ?", [t, run_id]
+        )
+            return t_switch_sum / (n_switch_immune + n_switch_not_immune)
+        end
+    end
+    compare_funcs("tswitch_overall", ts, db2, db3, should_plot, f, f)
+end
+
+function compare_tswitch_not_immune(ts, db2, db3, should_plot)
+    f = function(t, db, run_id)
+        for (n_switch_not_immune, t_switch_sum) in execute(db, 
+            "SELECT n_switch_not_immune, t_switch_sum FROM debug_stats WHERE time = ? AND run_id = ?", [t, run_id]
+        )
+            return t_switch_sum / n_switch_not_immune
+        end
+    end
+    compare_funcs("tswitch_not_immune", ts, db2, db3, should_plot, f, f)
+end
+
+function compare_n_bites_total(ts, db2, db3, should_plot)
+    compare_funcs("n_bites_total", ts, db2, db3, should_plot,
+        (
+            function(t, db, run_id)
+                for (n_bites,) in execute(db,
+                    "SELECT n_total_bites FROM summary WHERE time = ? AND run_id = ?", [t, run_id]
+                )
+                    return n_bites
+                end
+            end
+        ),
+        (
+            function(t, db, run_id)
+                for (n_bites,) in execute(db3,
+                    "SELECT n_bites FROM summary WHERE time = ? AND run_id = ?", [t, run_id]
+                )
+                    return n_bites
+                end
+            end
+        )
+    )
+end
+
+function compare_n_circulating_genes(ts, db2, db3, should_plot)
+    compare_funcs("n_circulating_genes", ts, db2, db3, should_plot,
+        (
+            function(t, db, run_id)
+                for (n_circulating_genes,) in execute(db,
+                    "SELECT n_circulating_genes FROM summary WHERE time = ? AND run_id = ?", [t, run_id]
+                )
+                    return n_circulating_genes
+                end
+            end
+        ),
+        (
+            function(t, db, run_id)
+                for (n_circulating_genes,) in execute(db3,
+                    "SELECT n_circulating_genes FROM gene_strain_counts WHERE time = ? AND run_id = ?", [t, run_id]
+                )
+                    return n_circulating_genes
+                end
+            end
+        )
+    )
+end
+
+function compare_n_circulating_strains(ts, db2, db3, should_plot)
+    compare_funcs("n_circulating_strains", ts, db2, db3, should_plot,
+        (
+            function(t, db, run_id)
+                for (n_circulating_strains,) in execute(db,
+                    "SELECT n_circulating_strains FROM summary WHERE time = ? AND run_id = ?", [t, run_id]
+                )
+                    return n_circulating_strains
+                end
+            end
+        ),
+        (
+            function(t, db, run_id)
+                for (n_circulating_strains,) in execute(db3,
+                    "SELECT n_circulating_strains FROM gene_strain_counts WHERE time = ? AND run_id = ?", [t, run_id]
+                )
+                    return n_circulating_strains
+                end
+            end
+        )
+    )
+end
+
+function compare_n_bites(ts, db2, db3, should_plot)
+    compare_funcs("n_bites", ts, db2, db3, should_plot,
+        (
+            function(t, db, run_id)
+                for (n_bites,) in execute(db,
+                    "SELECT n_total_bites FROM summary WHERE time = ? AND run_id = ?", [t, run_id]
+                )
+                    return n_bites
+                end
+            end
+        ),
+        (
+            function(t, db, run_id)
+                for (n_bites,) in execute(db3,
+                    "SELECT n_bites FROM summary WHERE time = ? AND run_id = ?", [t, run_id]
+                )
+                    return n_bites
+                end
+            end
+        )
+    )
+end
+
+function compare_n_infected_bites(ts, db2, db3, should_plot)
+    f = function(t, db, run_id)
+        for (n_infected_bites,) in execute(db,
+                "SELECT n_infected_bites FROM summary WHERE time = ? AND run_id = ?", [t, run_id]
+            )
+            return n_infected_bites
+        end
+    end
+    compare_funcs("n_infected_bites", ts, db2, db3, should_plot, f, f)
+end
+
+function compare_mean_age(ts, db2, db3, should_plot)
+    f = function(t, db, run_id)
+        for (mean_age,) in execute(db,
+                "SELECT mean_age FROM debug_stats WHERE time = ? AND run_id = ?", [t, run_id]
+            )
+            return mean_age
+        end
+    end
+    compare_funcs("mean_age", ts, db2, db3, should_plot, f, f)
+end
+
+function compare_sd_age(ts, db2, db3, should_plot)
+    f = function(t, db, run_id)
+        for (sd_age,) in execute(db,
+                "SELECT sd_age FROM debug_stats WHERE time = ? AND run_id = ?", [t, run_id]
+            )
+            return sd_age
+        end
+    end
+    compare_funcs("sd_age", ts, db2, db3, should_plot, f, f)
+end
+
+main()


### PR DESCRIPTION
To speed up drawing from an exponential distribution, this code wraps the distribution in a batch sampler, which performs many draws at once.

Basic testing found a 7% speedup for one set of parameters, and statistically indistinguishable behavior in terms of # active hosts and # circulating genes:

https://github.com/pascualgroup/varmodel-test-history/tree/main/2024-03-07-randexp-speedup

https://github.com/pascualgroup/varmodel-test-history/blob/main/2024-03-07-randexp-speedup/kscompare.ipynb