### PR TITLE
Eliminated batch draws, leading to a speedup, not a slowdown

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -119,12 +119,13 @@ function run_inner()
     event_dist = WeightedDiscreteDistribution(10.0, [get_rate(t, s, event) for event in EVENTS])
 
     # Batched exponential distribution for event loop draws
-    batched_exp_dist = BatchedDistribution(Exponential(1.0), P.rng_batch_size)
+    exp_dist = Exponential(1.0)
 
     # Loop events until end of simulation.
     while total_weight(event_dist) > 0.0 && t < P.t_end
         # Draw next time with rate equal to the sum of all event rates.
-        dt = @fastmath rand(rng, batched_exp_dist) / total_weight(event_dist)
+        # dt = @fastmath rand(rng, batched_exp_dist) / total_weight(event_dist)
+        dt = @fastmath rand(rng, exp_dist) / total_weight(event_dist)
         # @assert dt > 0.0 && !isinf(dt)
 
         # At each integer time, write output/state verification (if necessary),

--- a/src/util.jl
+++ b/src/util.jl
@@ -174,83 +174,20 @@ function get_key_by_iteration_order(d::Dict{K, V}, index::Int) where {K, V}
 end
 
 """
-State for a batched distribution.
-"""
-mutable struct BatchedDistribution
-    d::Sampleable{Univariate, Continuous}
-    draws::Vector{Float64}
-    next_draw_index::Int
-
-    function BatchedDistribution(d, batch_size)
-        draws = Vector(undef, batch_size)
-        next_draw_index = 1
-        new(d, draws, 1)
-    end
-end
-
-function Base.rand(rng::AbstractRNG, bd::BatchedDistribution)
-    if bd.next_draw_index == 1
-        rand!(rng, bd.d, bd.draws)
-    end
-    draw = bd.draws[bd.next_draw_index]
-    bd.next_draw_index = 1 + mod(bd.next_draw_index, length(bd.draws))
-    draw
-end
-
-"""
 State for a weighted discrete distribution
 """
 mutable struct WeightedDiscreteDistribution
-    # bin_size::Float64
     weights::Vector{Float64}
     total_weight::Float64
-    # bins::Vector{Int}
-    # bin_indices::Dict{Int, Set{Int}}
-    # p_accept::Vector{Float64}
-    # batch_dist::BatchedDistribution
 
     function WeightedDiscreteDistribution(bin_size, weights; rand_batch_size = 10000000)
-        # Initialize bins
-        # bins = Vector{Int}()
-        # bin_indices = Dict{Int, Set{Int}}()
-        # p_accept = Vector{Float64}()
-        # for i in 1:length(weights)
-        #     (n_bins, p_accept_i) = compute_n_bins_and_p_accept(weights[i], bin_size)
-        #     push!(p_accept, p_accept_i)
-
-        #     bin_indices[i] = Set((length(bins) + 1):(length(bins) + n_bins))
-        #     @assert length(bin_indices[i]) == n_bins
-        #     append!(bins, fill(i, n_bins))
-        # end
-        #println(p_accept)
-
-        # wdd = new(bin_size, weights, sum(weights), bins, bin_indices, p_accept, BatchedDistribution(Uniform(), rand_batch_size))
         wdd = new(weights, sum(weights))
-        # verify(wdd)
         wdd
     end
 end
 
 function Base.rand(rng::AbstractRNG, wdd::WeightedDiscreteDistribution)
-    # Repeat until a sample is accepted
-    # while true
-    #     item = rand(rng, wdd.bins) # TODO: batch this too if not fast enough
-    #     if rand(rng, wdd.batch_dist) < wdd.p_accept[item]
-    #         return item
-    #     end
-    # end
     direct_sample_linear_scan(rng, wdd.weights, wdd.total_weight)
-end
-
-function compute_n_bins_and_p_accept(weight, bin_size)
-    n_bins_fractional = weight / bin_size
-    n_bins_ceil = ceil(n_bins_fractional)
-
-    if n_bins_ceil == 0.0
-        (0, 0.0)
-    else
-        (Int(n_bins_ceil), n_bins_fractional / n_bins_ceil)
-    end
 end
 
 function total_weight(wdd::WeightedDiscreteDistribution)
@@ -261,55 +198,9 @@ function recompute_total_weight!(wdd::WeightedDiscreteDistribution)
     wdd.total_weight = sum(wdd.weights)
 end
 
-function verify(wdd::WeightedDiscreteDistribution)
-    for (item, weight) in enumerate(wdd.weights)
-        (n_bins, p_accept) = compute_n_bins_and_p_accept(weight, wdd.bin_size)
-        @assert wdd.p_accept[item] == p_accept
-        @assert length(wdd.bin_indices[item]) == n_bins
-        for bin_index in wdd.bin_indices[item]
-            @assert wdd.bins[bin_index] == item
-        end
-    end
-
-    for (bin_index, item) in enumerate(wdd.bins)
-        @assert bin_index in wdd.bin_indices[item]
-    end
-end
-
 function update!(wdd::WeightedDiscreteDistribution, item, weight)
     if weight != wdd.weights[item]
-        # n_bins_old = length(wdd.bin_indices[item])
-        # (n_bins_new, p_accept_new) = compute_n_bins_and_p_accept(weight, wdd.bin_size)
-
-        # # Adjust the number of bins, if necessary
-        # if n_bins_new > n_bins_old
-        #     for i in 1:(n_bins_new - n_bins_old)
-        #         push!(wdd.bins, item)
-        #         @assert !(length(wdd.bins) in wdd.bin_indices[item])
-        #         push!(wdd.bin_indices[item], length(wdd.bins))
-        #     end
-        # elseif n_bins_old > n_bins_new
-        #     for i in 1:(n_bins_old - n_bins_new)
-        #         bin_index_to_remove = pop!(wdd.bin_indices[item])
-        #         last_bin_index = length(wdd.bins)
-        #         moved_item = delete_and_swap_with_end!(wdd.bins, bin_index_to_remove)
-        #         if moved_item !== nothing
-        #             # Update the index set for the item that got moved from last_index
-        #             # to bin_index_to_remove
-        #             @assert last_bin_index in wdd.bin_indices[moved_item]
-        #             delete!(wdd.bin_indices[moved_item], last_bin_index)
-        #             @assert !(bin_index_to_remove in wdd.bin_indices[moved_item])
-        #             push!(wdd.bin_indices[moved_item], bin_index_to_remove)
-
-        #         end
-        #     end
-        # end
-
-        # Update the weight and acceptance probability
         wdd.total_weight += weight - wdd.weights[item] # May introduce error; periodically call recompute_total_weight!()
         wdd.weights[item] = weight
-        # wdd.p_accept[item] = p_accept_new
-
-        # verify(wdd)
     end
 end


### PR DESCRIPTION
With a stored RNG and `@fastmath`, removing batched draws seems to actually be *faster*. Eliminated batched draws in order to simplify the code (and, unexpectedly, speed it up).