### PR TITLE
Removed reused distribution

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -118,14 +118,10 @@ function run_inner()
     #weights = Weights(rates, total_rate)
     event_dist = WeightedDiscreteDistribution(10.0, [get_rate(t, s, event) for event in EVENTS])
 
-    # Batched exponential distribution for event loop draws
-    exp_dist = Exponential(1.0)
-
     # Loop events until end of simulation.
     while total_weight(event_dist) > 0.0 && t < P.t_end
         # Draw next time with rate equal to the sum of all event rates.
-        # dt = @fastmath rand(rng, batched_exp_dist) / total_weight(event_dist)
-        dt = @fastmath rand(rng, exp_dist) / total_weight(event_dist)
+        dt = @fastmath rand(rng, Exponential(1.0 / total_weight(event_dist)))
         # @assert dt > 0.0 && !isinf(dt)
 
         # At each integer time, write output/state verification (if necessary),


### PR DESCRIPTION
No performance difference or change in behavior when creating new `Exponential(...)` vs. reusing an `Exponential(1.0)`; switched to the easier-to-read version.