### PR TITLE
Stats eliminated prior to burnin

### DIFF
--- a/examples/julia/run.jl
+++ b/examples/julia/run.jl
@@ -44,7 +44,7 @@ const P = let
         summary_period = 30,
         gene_strain_count_period = t_year,
 
-        host_sampling_period = 30,
+        host_sampling_period = [30],
         host_sample_size = 100,
 
         verification_period = t_year,
@@ -95,8 +95,7 @@ const P = let
         switching_rate = [1.0/6.0, 1.0/6.0],
         # switching_rate = 1.0/6.0,
 
-        mean_host_lifetime = 30 * t_year,
-        max_host_lifetime = 80 * t_year,
+        mean_host_lifetime = 23.38837487739662 * t_year,
 
         background_clearance_rate = 0.0,
 
@@ -111,16 +110,6 @@ const P = let
 
         migrants_match_local_prevalence = true,
         migration_rate_update_period = 30,
-
-        n_snps_per_strain = 0,
-
-        distinct_initial_snp_allele_frequencies = false,
-#         distinct_initial_snp_allele_frequencies = true,
-#         initial_snp_allele_frequency = [0.1, 0.9],
-
-        snp_linkage_disequilibrium = false,
-#         snp_linkage_disequilibrium = true,
-#         snp_pairwise_ld = [snp_ld_matrix[:,i] for i in 1:size(snp_ld_matrix)[2]],
 
 
         

--- a/examples/julia/run.jl
+++ b/examples/julia/run.jl
@@ -36,7 +36,7 @@ const P = let
     t_burnin_years = 80
     t_burnin = t_burnin_years * t_year
 
-    Params(
+    add_params(Params(), (
         upper_bound_recomputation_period = 30,
 
         output_db_filename = "output.sqlite",
@@ -131,7 +131,7 @@ const P = let
         var_groups_do_not_share_alleles = true,
         var_groups_high_functionality_express_earlier = true,
         gene_group_id_association_recomputation_period = 30,
-    )
+    ))
 end
 
 # Load and run the model code, which can now be compiled with reference to

--- a/examples/sweep/generate-sweep.jl
+++ b/examples/sweep/generate-sweep.jl
@@ -115,12 +115,11 @@ function generate_runs(db)
 
             for replicate in 1:N_REPLICATES
                 rng_seed = rand(seed_rng, 1:typemax(Int64))
-                params = Params(
-                    base_params;
+                params = add_params(base_params, (
                     rng_seed = rng_seed,
                     mutation_rate = mutation_rate,
                     transmissibility = transmissibility
-                )
+                ))
 
                 run_dir = joinpath("runs", "c$(combo_id)", "r$(replicate)")
                 @assert !ispath(run_dir)
@@ -253,7 +252,7 @@ function init_base_params()
     t_burnin_years = 61
     t_burnin = t_burnin_years * t_year
 
-    Params(
+    add_params(Params(), (
         upper_bound_recomputation_period = 30,
 
         output_db_filename = "output.sqlite",
@@ -336,7 +335,7 @@ function init_base_params()
         snp_linkage_disequilibrium = false,
 #         snp_linkage_disequilibrium = true,
 #         snp_pairwise_ld = [snp_ld_matrix[:,i] for i in 1:size(snp_ld_matrix)[2]],
-    )
+    ))
 end
 
 main()

--- a/examples/sweep/generate-sweep.jl
+++ b/examples/sweep/generate-sweep.jl
@@ -49,6 +49,7 @@ using Random
 using SQLite
 import SQLite.DBInterface.execute
 using DelimitedFiles
+import DataStructures.OrderedDict
 
 # Get relevant paths and cd to the script path.
 # NB: use actual relative locations of varmodel3 root relative to your script.
@@ -230,7 +231,7 @@ function generate_jobs(db)
 end
 
 function pretty_json(params)
-    d = Dict(fn => getfield(params, fn) for fn in fieldnames(typeof(params)))
+    d = OrderedDict(fn => getfield(params, fn) for fn in fieldnames(typeof(params)))
     io = IOBuffer()
     JSON.print(io, d, 2)
     String(take!(io))
@@ -249,7 +250,7 @@ function init_base_params()
 #     biting_rate_multiplier_by_year = repeat([1.0], t_end_years)
 #     biting_rate_multiplier_by_year[61:62] .= 0.5
 
-    t_burnin_years = 61
+    t_burnin_years = 0
     t_burnin = t_burnin_years * t_year
 
     add_params(Params(), (
@@ -260,7 +261,7 @@ function init_base_params()
         summary_period = 30,
         gene_strain_count_period = t_year,
 
-        host_sampling_period = 30,
+        host_sampling_period = [30],
         host_sample_size = 100,
 
         verification_period = t_year,
@@ -274,9 +275,9 @@ function init_base_params()
         t_year = t_year,
         t_end = t_end,
 
-        t_burnin = t_end,
+        t_burnin = t_burnin,
 
-        n_hosts = 10000,
+        n_hosts = 1000,
         n_initial_infections = 20,
 
         n_genes_initial = 9600,
@@ -289,7 +290,8 @@ function init_base_params()
         transmissibility = 0.5,
         coinfection_reduces_transmission = true,
 
-        ectopic_recombination_rate = 1.8e-7,
+        # ectopic_recombination_rate = 1.8e-7,
+        ectopic_recombination_rate = [4.242641e-4, 4.242641e-4],
         p_ectopic_recombination_is_conversion = 0.0,
 
         ectopic_recombination_generates_new_alleles = false,
@@ -307,10 +309,9 @@ function init_base_params()
 
         t_liver_stage = 14.0,
 
-        switching_rate = 1.0/6.0,
+        switching_rate = [1.0/6.0, 1.0/6.0],
 
-        mean_host_lifetime = 30 * t_year,
-        max_host_lifetime = 80 * t_year,
+        mean_host_lifetime = 23.38837487739662 * t_year,
 
         background_clearance_rate = 0.0,
 
@@ -325,16 +326,14 @@ function init_base_params()
 
         migrants_match_local_prevalence = true,
         migration_rate_update_period = 30,
-
-        n_snps_per_strain = 24,
-
-        distinct_initial_snp_allele_frequencies = false,
-#         distinct_initial_snp_allele_frequencies = true,
-#         initial_snp_allele_frequency = [0.1, 0.9],
-
-        snp_linkage_disequilibrium = false,
-#         snp_linkage_disequilibrium = true,
-#         snp_pairwise_ld = [snp_ld_matrix[:,i] for i in 1:size(snp_ld_matrix)[2]],
+        
+        # parameters for var groups implementation
+        var_groups_functionality = [1, 1],
+        var_groups_ratio = [0.25, 0.75],
+        var_groups_fix_ratio = true,
+        var_groups_do_not_share_alleles = true,
+        var_groups_high_functionality_express_earlier = true,
+        gene_group_id_association_recomputation_period = 30,
     ))
 end
 

--- a/run.jl
+++ b/run.jl
@@ -28,8 +28,7 @@ const P = let
 
     json_str = read(params_filename, String)
     json_odict = JSON.parse(json_str, dicttype=OrderedDict)
-    params = Params()
-    assign_fields!(params, json_odict)
+    params = add_params(Params(), json_odict)
     params
 end
 

--- a/run.jl
+++ b/run.jl
@@ -13,6 +13,8 @@ argument. (If not provided, "parameters.json" is assumed.)
 
 include("preamble.jl")
 
+import DataStructures.OrderedDict
+
 # Load parameters into a constant global, so that they can be used when compiling
 # the model code.
 const P = let
@@ -25,10 +27,10 @@ const P = let
     end
 
     json_str = read(params_filename, String)
-
-    d_str = JSON.parse(json_str)
-    d_symb = Dict((Symbol(k), v) for (k, v) in d_str)
-    Params(; d_symb...)
+    json_odict = JSON.parse(json_str, dicttype=OrderedDict)
+    params = Params()
+    assign_fields!(params, json_odict)
+    params
 end
 
 include("src/model.jl")

--- a/src/model.jl
+++ b/src/model.jl
@@ -74,14 +74,14 @@ function run()
 end
 
 function profile()
-    println("Running with profiling on...")
+    println(stderr, "Running with profiling on...")
     Profile.init(n = 10^7, delay = P.profile_delay)
     @Profile.profile run_inner()
 
-    println("About to write profile...")
+    println(stderr, "About to write profile...")
     profile_data = Profile.retrieve()
     Serialization.serialize(P.profile_filename, profile_data)
-    println("Profile written.")
+    println(stderr, "Profile written.")
 end
 
 function run_inner()
@@ -169,23 +169,23 @@ function run_inner()
     end
 
     elapsed_time = Dates.value(now() - start_datetime) / 1000.0
-    println("elapsed time (s): $(elapsed_time)")
+    println(stderr, "elapsed time (s): $(elapsed_time)")
     execute(db.meta, ("elapsed_time", elapsed_time))
     
     max_rss_gb = Sys.maxrss() / 2^30
-    println("maxrss (GB) = $(max_rss_gb)")
+    println(stderr, "maxrss (GB) = $(max_rss_gb)")
     execute(db.meta, ("max_rss_gb", max_rss_gb))
 
     went_extinct = total_weight(event_dist) == 0.0
-    println("went extinct? $(went_extinct)")
+    println(stderr, "went extinct? $(went_extinct)")
     execute(db.meta, ("went_extinct", Int64(went_extinct)))
 
     total_num_genes_generated_mut = s.next_gene_id_mut - 1
-    println("total number of new genes generated out of mutation? $(total_num_genes_generated_mut)")
+    println(stderr, "total number of new genes generated out of mutation? $(total_num_genes_generated_mut)")
     execute(db.meta, ("total_num_genes_generated_mut", Int64(total_num_genes_generated_mut)))
 
     total_num_genes_generated_recomb = s.next_gene_id_recomb - 1
-    println("total number of new genes generated out of recombination? $(total_num_genes_generated_recomb)")
+    println(stderr, "total number of new genes generated out of recombination? $(total_num_genes_generated_recomb)")
     execute(db.meta, ("total_num_genes_generated_recomb", Int64(total_num_genes_generated_recomb)))
 end
 
@@ -247,7 +247,7 @@ end
 
 #function initialize_state(a)
 function initialize_state(rng)
-    println("initialize_state()")
+    println(stderr, "initialize_state()")
 
     # Initialize gene pool as an (n_loci, n_genes_initial) matrix whose columns
     # are unique randomly generated genes. Initialize gene-to-group-id map as an empty dictionary.
@@ -577,7 +577,7 @@ function do_biting!(t, s, stats, event_dist)
     end
     
     transmitted_strains = src_host.active_infections[choose_transmit.<p_transmit*infs_transmissibility]
-    #println("t = $(t): originalSize $(src_active_count), newSize $(length(transmitted_strains))")
+    #println(stderr, "t = $(t): originalSize $(src_active_count), newSize $(length(transmitted_strains))")
 
     # The number of transmissions is bounded by the number of source infections
     # and the number of available slots in the destination.
@@ -727,7 +727,7 @@ function do_background_clearance(t, s, stats, event_dist)
         false
     else
         infection = host.active_infections[inf_index]
-        #println("do_background_clearance actually happening")
+        #println(stderr, "do_background_clearance actually happening")
         clear_active_infection!(t, s, host, inf_index)
         true
     end

--- a/src/model.jl
+++ b/src/model.jl
@@ -247,8 +247,6 @@ end
 
 #function initialize_state(a)
 function initialize_state(rng)
-    println(stderr, "initialize_state()")
-
     # Initialize gene pool as an (n_loci, n_genes_initial) matrix whose columns
     # are unique randomly generated genes. Initialize gene-to-group-id map as an empty dictionary.
     gene_pool_set = Set()
@@ -335,22 +333,6 @@ function initialize_state(rng)
         infected_ratio = 1.0,
         association_genes_to_var_groups = association_genes_to_var_groups_init
     )
-end
-
-"""
-    Draws host lifetime from a distribution.
-
-    The distribution is an exponential distribution with mean
-    `mean_host_lifetime`, truncated at `max_host_lifetime`.
-"""
-function draw_host_lifetime(rng)
-    dist = Exponential(P.mean_host_lifetime)
-    while true
-        lifetime = rand(rng, dist)
-        if lifetime < P.max_host_lifetime
-            return lifetime
-        end
-    end
 end
 
 function create_empty_infection(id, t)

--- a/src/output.jl
+++ b/src/output.jl
@@ -74,6 +74,72 @@ function reset!(stats::SummaryStats, start_datetime)
 end
 
 """
+Increment # events
+"""
+function increment_n_events!(stats::SummaryStats)
+    stats.n_events += 1
+end
+
+function increment_n_events!(stats::Nothing)
+    nothing
+end
+
+"""
+Increment # bites
+"""
+function increment_n_bites!(stats::SummaryStats)
+    stats.n_bites += 1
+end
+
+function increment_n_bites!(stats::Nothing)
+    nothing
+end
+
+"""
+Increment # infected bites
+"""
+function increment_n_infected_bites!(stats::SummaryStats)
+    stats.n_infected_bites += 1
+end
+
+function increment_n_infected_bites!(stats::Nothing)
+    nothing
+end
+
+"""
+Increment # infected bites w/ space
+"""
+function increment_n_infected_bites_with_space!(stats::SummaryStats)
+    stats.n_infected_bites_with_space += 1
+end
+
+function increment_n_infected_bites_with_space!(stats::Nothing)
+    nothing
+end
+
+"""
+Increment # transmissions
+"""
+function increment_n_transmissions!(stats::SummaryStats)
+    stats.n_transmissions += 1
+end
+
+function increment_n_transmissions!(stats::Nothing)
+    nothing
+end
+
+"""
+Increment # transmitting bites
+"""
+function increment_n_transmitting_bites!(stats::SummaryStats)
+    stats.n_transmitting_bites += 1
+end
+
+function increment_n_transmitting_bites!(stats::Nothing)
+    nothing
+end
+
+"""
 Pass commands issued to a `VarModelDB` on to the underlying `SQLite.DB`.
 """
 function execute(db::VarModelDB, cmd)
@@ -210,11 +276,11 @@ end
 
 ### OUTPUT FUNCTIONS ###
 
-function write_output!(db, t, s, stats)
-    if P.t_burnin !== nothing && t < P.t_burnin
-        return
-    end
+function write_output!(db, t, s, stats::Nothing)
+    nothing
+end
 
+function write_output!(db, t, s, stats::SummaryStats)
     if t % P.summary_period == 0 || t % P.gene_strain_count_period == 0 || (((P.t_host_sampling_start !== nothing && t >= P.t_host_sampling_start) || P.t_host_sampling_start === nothing) && t % P.t_year in P.host_sampling_period)
         println(stderr, "t = $(t)")
 

--- a/src/output.jl
+++ b/src/output.jl
@@ -216,7 +216,7 @@ function write_output!(db, t, s, stats)
     end
 
     if t % P.summary_period == 0 || t % P.gene_strain_count_period == 0 || (((P.t_host_sampling_start !== nothing && t >= P.t_host_sampling_start) || P.t_host_sampling_start === nothing) && t % P.t_year in P.host_sampling_period)
-        println("t = $(t)")
+        println(stderr, "t = $(t)")
 
         execute(db, "BEGIN TRANSACTION")
 
@@ -234,6 +234,7 @@ function write_output!(db, t, s, stats)
         end        
 
         execute(db, "COMMIT")
+        flush(stderr)
         flush(stdout)
     end
 end

--- a/src/state.jl
+++ b/src/state.jl
@@ -321,7 +321,7 @@ end
 Verify that various pieces of state are consistent with each other.
 """
 function verify(t, s::State)
-    println("verify($(t), s)")
+    println(stderr, "verify($(t), s)")
 
     # Verify that gene pool consists of all unique genes
     gene_pool_set = Set()

--- a/src/util.jl
+++ b/src/util.jl
@@ -4,6 +4,7 @@ import Base.push!
 import Base.delete!
 import Base.rand
 import Random.rand!
+import Random.AbstractRNG
 import Base.length
 import Base.iterate
 import Base.in
@@ -204,3 +205,6 @@ function update!(wdd::WeightedDiscreteDistribution, item, weight)
         wdd.weights[item] = weight
     end
 end
+
+"""
+"""


### PR DESCRIPTION
I eliminated stats gathering prior to burnin.

For duration sampling, I simply put an if statement around the operation to record a sampled duration.

For other stats, I set the value of `stats` to be `nothing` prior to burnin, and replaced the lines incrementing individual stats with function calls that are dispatched to different versions of the function for the `Nothing` type and for the `SummaryStats` type.

One weirdness: `n_bites` etc. are reported as `0`. This is how it was for `t = 0` with `t_burnin == 0`, so it's consistent, but it would be more rigorous to output these values as, e.g., `NULL` in the database. Which would you prefer @qzhan321 ?